### PR TITLE
CollectionPropertyBinder improvement.

### DIFF
--- a/src/FubuCore.Testing/Binding/CollectionPropertyBinderTester.cs
+++ b/src/FubuCore.Testing/Binding/CollectionPropertyBinderTester.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using FubuCore.Binding;
 using FubuCore.Reflection;
 using FubuTestingSupport;
@@ -49,6 +50,27 @@ namespace FubuCore.Testing.Binding
             propertyBinder.Bind(property, context);
 
             model.Localities[0].ZipCode.ShouldEqual("84115");
+        }
+
+        [Test]
+        public void existing_collection_is_not_discarded()
+        {
+            var model = new AddressViewModel
+            {
+                Localities = new List<LocalityViewModel>
+                {
+                    new LocalityViewModel {ZipCode = "previously_set_zipcode"}
+                }
+            };
+
+            context.WithData("Localities[0]ZipCode", "84115");
+            context.StartObject(model);
+
+            var property = ReflectionHelper.GetProperty<AddressViewModel>(x => x.Localities);
+            propertyBinder.Bind(property, context);
+
+            model.Localities[0].ZipCode.ShouldEqual("previously_set_zipcode");
+            model.Localities[1].ZipCode.ShouldEqual("84115");
         }
     }
 }

--- a/src/FubuCore/Binding/CollectionPropertyBinder.cs
+++ b/src/FubuCore/Binding/CollectionPropertyBinder.cs
@@ -33,7 +33,8 @@ namespace FubuCore.Binding
                 type = _collectionTypeProvider.GetCollectionType(type, itemType);
             }
 
-            object collection = Activator.CreateInstance(type);
+            var currentCollection = property.GetValue(context.Object, null);
+            object collection = currentCollection ?? Activator.CreateInstance(type);
             var collectionType = collection.GetType();
 
             Func<object, bool> addToCollection = obj =>


### PR DESCRIPTION
CollectionPropertyBinder checks for existing collection before it creates a new. Closes FubuMVC issue 196. Eventual binding will be appended to the collection.

https://github.com/DarthFubuMVC/fubumvc/issues/196
