### PR TITLE
Introduced ObjectTypeFamily

### DIFF
--- a/src/FubuCore.Testing/Binding/ObjectTypeFamilyTester.cs
+++ b/src/FubuCore.Testing/Binding/ObjectTypeFamilyTester.cs
@@ -1,0 +1,48 @@
+using System.Reflection;
+using FubuCore.Binding;
+using FubuCore.Reflection;
+using FubuTestingSupport;
+using NUnit.Framework;
+
+namespace FubuCore.Testing.Binding
+{
+    [TestFixture]
+    public class ObjectTypeFamilyTester : InteractionContext<ObjectTypeFamily>
+    {
+        private PropertyInfo _objectProperty;
+        private PropertyInfo _stringProperty;
+        private object _value;
+        protected override void beforeEach()
+        {
+            _objectProperty = ReflectionHelper.GetProperty<MyModel>(p => p.ObjectProperty);
+            _stringProperty = ReflectionHelper.GetProperty<MyModel>(p => p.StringProperty);
+            _value = "value";
+        }
+
+        [Test]
+        public void matches_for_property_of_object_type_positive()
+        {
+            ClassUnderTest.Matches(_objectProperty).ShouldBeTrue();
+        }
+
+        [Test]
+        public void matches_for_property_of_object_type_negative()
+        {
+            ClassUnderTest.Matches(_stringProperty).ShouldBeFalse();
+        }
+
+        [Test]
+        public void convert_returns_the_context_property_value()
+        {
+            ClassUnderTest.Convert(new InMemoryBindingContext().WithPropertyValue(_value)).ShouldEqual(_value);
+        }
+
+
+        public class MyModel
+        {
+            public object ObjectProperty { get; set; }
+            public string StringProperty { get; set; }
+        }
+
+    }
+}

--- a/src/FubuCore.Testing/Binding/PassthroughBinderTester.cs
+++ b/src/FubuCore.Testing/Binding/PassthroughBinderTester.cs
@@ -33,6 +33,13 @@ namespace FubuCore.Testing.Binding
         }
 
         [Test]
+        public void matches_by_object_property_type_negative()
+        {
+            var binder = new PassthroughConverter<HttpPostedFileBase>();
+            binder.Matches(property(x => x.File3)).ShouldBeFalse();
+        }
+
+        [Test]
         public void build_passes_through()
         {
             var binder = new PassthroughConverter<HttpPostedFileBase>();
@@ -53,5 +60,6 @@ namespace FubuCore.Testing.Binding
     {
         public HttpPostedFileBase File { get; set; }
         public string File2 { get; set; }
+        public object File3 { get; set; }
     }
 }

--- a/src/FubuCore.Testing/FubuCore.Testing.csproj
+++ b/src/FubuCore.Testing/FubuCore.Testing.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Binding\ModelBinderCacheTester.cs" />
     <Compile Include="Binding\NestedObjectConversionIntegrationTester.cs" />
     <Compile Include="Binding\ObjectResolverTester.cs" />
+    <Compile Include="Binding\ObjectTypeFamilyTester.cs" />
     <Compile Include="Binding\PassthroughBinderTester.cs" />
     <Compile Include="Binding\PropertyBinderCacheTester.cs" />
     <Compile Include="Binding\PropertyBinderTester.cs" />

--- a/src/FubuCore/Binding/ObjectTypeFamily.cs
+++ b/src/FubuCore/Binding/ObjectTypeFamily.cs
@@ -1,0 +1,17 @@
+using System.Reflection;
+
+namespace FubuCore.Binding
+{
+    public class ObjectTypeFamily : StatelessConverter
+    {
+        public override bool Matches(PropertyInfo property)
+        {
+            return property.PropertyType == typeof(object);
+        }
+
+        public override object Convert(IPropertyContext context)
+        {
+            return context.PropertyValue;
+        }
+    }
+}

--- a/src/FubuCore/Binding/PassthroughConverter.cs
+++ b/src/FubuCore/Binding/PassthroughConverter.cs
@@ -7,7 +7,7 @@ namespace FubuCore.Binding
     {
         public override bool Matches(PropertyInfo property)
         {
-            return property.PropertyType.IsAssignableFrom(typeof (T));
+            return property.PropertyType.IsAssignableFrom(typeof(T)) && property.PropertyType != typeof(object);
         }
 
         public override object Convert(IPropertyContext context)

--- a/src/FubuCore/Binding/ValueConverterRegistry.cs
+++ b/src/FubuCore/Binding/ValueConverterRegistry.cs
@@ -40,6 +40,7 @@ namespace FubuCore.Binding
 
             Add<BooleanFamily>();
             Add<NumericTypeFamily>();
+            Add<ObjectTypeFamily>();
         }
 
         public void Add<T>() where T : IConverterFamily, new()

--- a/src/FubuCore/FubuCore.csproj
+++ b/src/FubuCore/FubuCore.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Binding\NestedObjectPropertyBinder.cs" />
     <Compile Include="Binding\NumericTypeFamily.cs" />
     <Compile Include="Binding\ObjectResolver.cs" />
+    <Compile Include="Binding\ObjectTypeFamily.cs" />
     <Compile Include="Binding\PassthroughConverter.cs" />
     <Compile Include="Binding\PrefixedRequestData.cs" />
     <Compile Include="Binding\PropertyBinderCache.cs" />


### PR DESCRIPTION
If you look at 6675c623dd593de16f617277416764043e45f256, the usage of PassthroughConverter has been removed from fubucore.

Also, fubumvc updated itself to this change by introducing its own aspnet specific converter family:
https://github.com/DarthFubuMVC/fubumvc/commit/a07dc932a093da74f95fb02e56e50b4eddd0fce2#L0R222
https://github.com/DarthFubuMVC/fubumvc/commit/a07dc932a093da74f95fb02e56e50b4eddd0fce2#diff-2

This custom family converter does not inherits from PassthroughConverter, and has a smarter and simpler check to know whether should or shouldn't build a converter.

However, the usage of PassthroughConverter brought to the game a subtle feature, the allowance to bind properties of System.Object type, so, it was enough to have at least a single PassthroughConverter to enable this, because, let's say, for PassthroughConverter&lt;HttpPostedFileBase&gt; Matches method:
return property.PropertyType.IsAssignableFrom(typeof (HttpPostedFileBase));
Returned true for properties of HttpPostedFileBase type (as expected), but also for properties of System.Object type (because you can assign an instance of HttpPostedFileBase to a property of System.Object type).

I have introduced a ObjectTypeFamily class which explicitly checks that the property type is System.Object, bringing back the feature to bind request values to System.Object properties.
