### PR TITLE
Exposed RequestData inside BindingContext to get at prefix

### DIFF
--- a/src/FubuCore/Binding/BindingContext.cs
+++ b/src/FubuCore/Binding/BindingContext.cs
@@ -44,6 +44,11 @@ namespace FubuCore.Binding
             _request = new Lazy<ISmartRequest>(() => new SmartRequest(_requestData, _locator.GetInstance<IObjectConverter>()));
         }
 
+        public IRequestData RequestData
+        {
+            get { return _requestData; }
+        }
+
         public IBindingLogger Logger
         {
             get { return _logger; }

--- a/src/FubuCore/Binding/IBindingContext.cs
+++ b/src/FubuCore/Binding/IBindingContext.cs
@@ -35,6 +35,11 @@ namespace FubuCore.Binding
     /// </summary>
     public interface IBindingContext
     {
+        /// <summary>
+        /// Expose the current (possibly prefixed) request data so property binders can use it
+        /// to dig around for values according to their needs
+        /// </summary>
+        IRequestData RequestData { get; }
 
         /// <summary>
         /// Expose logging to the model binding subsystem


### PR DESCRIPTION
Since the request data contains the prefix that has been applied thus far in the binding process, it is needed by property binders in order to implement new behavior correctly.

For example, we have a new DateTimePropertyBinder that splits a DateTime into three parts:

PropertyName + "Day"
PropertyName + "Month"
PropertyName + "Year"

We were using the BindingContext.Service<IRequestData> to obtain the request data to look for these new values, however in a collection binding scenario we require the binding contexts prefixed request data instead of the one we would resolve from the container this way in order to make it look like Collection[0]PropertyName
