### PR TITLE
Fixed bug causing settings sources to get evaluated 4 times rather than once

### DIFF
--- a/src/FubuCore.Testing/Configuration/Settings_provider_sources.cs
+++ b/src/FubuCore.Testing/Configuration/Settings_provider_sources.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using FubuCore.Binding;
+using FubuCore.Configuration;
+using FubuTestingSupport;
+using NUnit.Framework;
+
+namespace FubuCore.Testing.Configuration
+{
+    [TestFixture]
+    public class Settings_provider_sources
+    {
+        private SettingsProvider theProvider;
+        private TestSettingsSource _settingsSource;
+
+
+        public class TestSettingsSource : ISettingsSource
+        {
+            public int FindOccurrenceCount { get; set; }
+
+            public IEnumerable<SettingsData> FindSettingData()
+            {
+                FindOccurrenceCount += 1;
+                return new[] {new SettingsData(SettingCategory.profile)};
+            }
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            var resolver = ObjectResolver.Basic();
+            _settingsSource = _settingsSource = new TestSettingsSource();
+            theProvider = new SettingsProvider(resolver, new[] { _settingsSource });
+        }
+
+        [Test]
+        public void should_only_find_their_settings_once()
+        {
+            theProvider.SettingsFor<OneSettings>();
+
+            _settingsSource.FindOccurrenceCount.ShouldEqual(1);
+        }
+    }
+}

--- a/src/FubuCore.Testing/FubuCore.Testing.csproj
+++ b/src/FubuCore.Testing/FubuCore.Testing.csproj
@@ -105,6 +105,7 @@
     <Compile Include="Binding\Values\ValueDiagnosticReportTester.cs" />
     <Compile Include="Configuration\AppSettingsKeyValuesTester.cs" />
     <Compile Include="Configuration\AppSettingsProviderIntegratedTester.cs" />
+    <Compile Include="Configuration\Settings_provider_sources.cs" />
     <Compile Include="Conversion\descriptions_on_every_converter.cs" />
     <Compile Include="Conversion\TimeSpanConverterTester.cs" />
     <Compile Include="Conversion\TypeDescripterConverterFamilyTester.cs" />

--- a/src/FubuCore/Configuration/SettingsProvider.cs
+++ b/src/FubuCore/Configuration/SettingsProvider.cs
@@ -25,7 +25,7 @@ namespace FubuCore.Configuration
 
             _settings = new Lazy<IEnumerable<SettingsData>>(() =>
             {
-                var allSettings = sources.SelectMany(x => x.FindSettingData());
+                var allSettings = sources.SelectMany(x => x.FindSettingData()).ToArray();
                 return SettingsData.Order(allSettings);
             });
 


### PR DESCRIPTION
Noticed this while spelunking around the settings provider stuff with FubuCore. Not a big deal but best not to have settings sources get hit multiple times. 
