### PR TITLE
Enhancing the BindingContext to issue sub contexts

### DIFF
--- a/src/FubuCore/Binding/IBindingContext.cs
+++ b/src/FubuCore/Binding/IBindingContext.cs
@@ -50,6 +50,7 @@ namespace FubuCore.Binding
         /// <param name="continuation"></param>
         /// <returns></returns>
         void BindObject(IRequestData data, Type type, Action<object> continuation);
+        void BindObject(Type type, Action<object> continuation);
 
         /// <summary>
         /// Binds property values to an existing object
@@ -58,7 +59,11 @@ namespace FubuCore.Binding
         void BindProperties(object instance);
 
         IEnumerable<IRequestData> GetEnumerableRequests(string name);
+
+        [MarkedForTermination("No usages in FubuCore - dru")]
         IRequestData GetSubRequest(string name);
+
+        IBindingContext GetSubContext(string name);
 
         /// <summary>
         /// The current object being bound

--- a/src/FubuCore/Binding/NestedObjectPropertyBinder.cs
+++ b/src/FubuCore/Binding/NestedObjectPropertyBinder.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Reflection;
 
@@ -20,8 +18,8 @@ namespace FubuCore.Binding
                 return;
             }
 
-            var childRequest = context.GetSubRequest(property.Name);
-            context.BindObject(childRequest, property.PropertyType, o =>
+            var childContext = context.GetSubContext(property.Name);
+            childContext.BindObject(property.PropertyType, o =>
             {
                 property.SetValue(context.Object, o, null);
             });


### PR DESCRIPTION
An enhancement to the BindingContext, that is needed for FubuFastPack EditEntityModelBinder. This pull request adds a 'GetSubContext(string name)' method that return a new context object, that is scoped with nested request data. 

Discussions with JDM, also brought up the possible issue, that 'Problems' would get lost by spinning up a new context object. To that end I have added, a new ctor that allows the parent object to pass in ITS _problems. This ctor additional allows the problems to keep being collected in the parent context. 

All tests are green.

In addition, it may now be possible to remove GetSubRequest from the context, as it is no longer used in FubuCore.
