### PR TITLE
DateTimeConverter converts ISO 8601 UTC datetimes to Local

### DIFF
--- a/src/FubuCore.Testing/Conversion/ObjectConverterTester.cs
+++ b/src/FubuCore.Testing/Conversion/ObjectConverterTester.cs
@@ -5,9 +5,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using FubuCore.Conversion;
-using FubuCore.Testing.Binding;
 using FubuCore.Testing.Formatting;
-using FubuCore.Util;
 using FubuTestingSupport;
 using NUnit.Framework;
 using Address = FubuCore.Testing.Formatting.Address;
@@ -103,7 +101,7 @@ namespace FubuCore.Testing.Conversion
         {
             finder.CanBeParsed(typeof(IEnumerable<Weird>)).ShouldBeFalse();
         }
-
+		
         [Test]
         public void time_zone_info()
         {
@@ -179,6 +177,23 @@ namespace FubuCore.Testing.Conversion
             date.Date.AddHours(14).AddMinutes(30).ShouldEqual(date);
             (date >= DateTime.Today).ShouldBeTrue();
         }
+
+		[Test]
+		public void get_date_time_from_full_iso_8601_should_be_a_utc_datetime()
+		{
+			var date = DateTimeConverter.GetDateTime("2012-06-01T14:52:35.0000000Z");
+
+			date.ShouldEqual(new DateTime(2012, 06, 01, 14, 52, 35, DateTimeKind.Utc));
+		}
+
+		[Test]
+		public void get_date_time_from_partial_iso_8601_uses_default_parser_and_is_local()
+		{
+			var date = DateTimeConverter.GetDateTime("2012-06-01T12:52:35Z");
+
+			var gmtOffsetInHours = (int) TimeZone.CurrentTimeZone.GetUtcOffset(date).TotalHours;
+			date.ShouldEqual(new DateTime(2012, 06, 01, 12 + gmtOffsetInHours, 52, 35, DateTimeKind.Local));
+		}
 
         [Test]
         public void get_date_time_from_24_hour_time()

--- a/src/FubuCore/Conversion/DateTimeConverter.cs
+++ b/src/FubuCore/Conversion/DateTimeConverter.cs
@@ -1,6 +1,8 @@
 using System;
 using System.ComponentModel;
+using System.Globalization;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace FubuCore.Conversion
 {
@@ -8,6 +10,8 @@ namespace FubuCore.Conversion
     public class DateTimeConverter : StatelessConverter<DateTime>
     {
         public const string TODAY = "TODAY";
+
+		private static readonly Regex iso8601Expression = new Regex(@"^([\+-]?\d{4}(?!\d{2}\b))((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]|3[01]))?|W([0-4]\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[1-6])))([T\s]((([01]\d|2[0-3])((:?)[0-5]\d)?|24\:?00)([\.,]\d+(?!:))?)?(\17[0-5]\d([\.,]\d+)?)?([zZ]|([\+-])([01]\d|2[0-3]):?([0-5]\d)?)?)?)?$");
 
         protected override DateTime convert(string text)
         {
@@ -34,6 +38,15 @@ namespace FubuCore.Conversion
             {
                 return convertToDateFromDayAndTime(dateString);
             }
+
+			if (iso8601Expression.IsMatch(trimmedString))
+			{
+				//Thank you jon skeet : http://stackoverflow.com/questions/10029099/datetime-parse2012-09-30t230000-0000000z-always-converts-to-datetimekind-l
+				DateTime result;
+				var success = DateTime.TryParseExact(trimmedString, "yyyy-MM-dd'T'HH:mm:ss.fffffff'Z'", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out result);
+
+				if (success) return result;
+			}
 
             return DateTime.Parse(trimmedString);
         }


### PR DESCRIPTION
When dates are posted to Fubu from backbone they use ISO8601 strings as UTC datetimes. They look like this: 

``` js
{ mydate : "2012-06-01T14:52:35.4321000Z" }  //<--- the trailing Z makes it UTC
```

FubuCore's [DateTimeConverter uses DateTime.Parse](https://github.com/DarthFubuMVC/fubucore/blob/master/src/FubuCore/Conversion/DateTimeConverter.cs#l38) as a backstop to convert general strings to datetimes. Problem here is the UTC datetime coming in is converted to a localtime by DateTime.Parse. 

I found [a rather detailed StackOverflow post](http://stackoverflow.com/questions/10029099/datetime-parse2012-09-30t230000-0000000z-always-converts-to-datetimekind-l) on this problem. 
### Proposed Fix

I glued together a [regex to detect 8601 datetimes](http://www.pelagodesign.com/blog/2009/05/20/iso-8601-date-validation-that-doesnt-suck/) and Jon Skeet's parse exact suggestion from the SO post I linked earlier and added a special case to handle full ISO 8601 datetimes. The regex is a bit huge and the parseexact method only supports one encoding of ISO8601. 

This may be a little to special case for everyone's taste.  
### Do it yourself?

I am happy to implement this fix as custom stateless converter. This pull request is really to see if this should be a standard way dates are handled.
### Workaround

In your action you can call `inputModel.datePropety.ToUniversalTime()` where you care that your datetimes are not UTC. This can be potentially problematic as Skeet points out in the SO post. 
