### PR TITLE
Use AddHours as entering an hour value of 24 to the datetime contructor ...

### DIFF
--- a/src/FubuCore.Testing/Conversion/ObjectConverterTester.cs
+++ b/src/FubuCore.Testing/Conversion/ObjectConverterTester.cs
@@ -192,7 +192,7 @@ namespace FubuCore.Testing.Conversion
 			var date = DateTimeConverter.GetDateTime("2012-06-01T12:52:35Z");
 
 			var gmtOffsetInHours = (int) TimeZone.CurrentTimeZone.GetUtcOffset(date).TotalHours;
-			date.ShouldEqual(new DateTime(2012, 06, 01, 12 + gmtOffsetInHours, 52, 35, DateTimeKind.Local));
+			date.ShouldEqual(new DateTime(2012, 06, 01, 12, 52, 35, DateTimeKind.Local).AddHours(gmtOffsetInHours));
 		}
 
         [Test]


### PR DESCRIPTION
Sadly I live in NZDT which just happens to be either +12 or +13 hours GMT.

This unit test fails on BOTH mono/linux and .net/windows due to my timezone.

Please support NZ :)

Errors and Failures:
1) Test Error : FubuCore.Testing.Conversion.ObjectConverterTester.get_date_time_from_partial_iso_8601_uses_default_parser_and_is_local
   System.ArgumentOutOfRangeException : Argument is out of range.
Parameter name: Parameters describe an unrepresentable DateTime.
  at System.DateTime..ctor (Int32 year, Int32 month, Int32 day, Int32 hour, Int32 minute, Int32 second, Int32 millisecond) [0x00000] in <filename unknown>:0 
  at System.DateTime..ctor (Int32 year, Int32 month, Int32 day, Int32 hour, Int32 minute, Int32 second) [0x00000] in <filename unknown>:0 
  at System.DateTime..ctor (Int32 year, Int32 month, Int32 day, Int32 hour, Int32 minute, Int32 second, DateTimeKind kind) [0x00000] in <filename unknown>:0 
  at FubuCore.Testing.Conversion.ObjectConverterTester.get_date_time_from_partial_iso_8601_uses_default_parser_and_is_local () [0x00000] in <filename unknown>:0 
  at (wrapper managed-to-native) System.Reflection.MonoMethod:InternalInvoke (System.Reflection.MonoMethod,object,object[],System.Exception&)
  at System.Reflection.MonoMethod.Invoke (System.Object obj, BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00000] in <filename unknown>:0
