### PR TITLE
Cache thread safety

### DIFF
--- a/src/FubuCore.Testing/Binding/Values/PrefixedKeyValuesTester.cs
+++ b/src/FubuCore.Testing/Binding/Values/PrefixedKeyValuesTester.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using FubuCore.Binding.Values;
 using NUnit.Framework;
 using FubuTestingSupport;
@@ -50,7 +51,7 @@ namespace FubuCore.Testing.Binding.Values
             theValues["OneKey5"] = "a";
             theValues["OneKey6"] = "a";
 
-            thePrefixedValues.GetKeys().ShouldHaveTheSameElementsAs("Key4", "Key5", "Key6");
+            thePrefixedValues.GetKeys().ToList().Matches("Key4", "Key5", "Key6");
         }
 
         [Test]

--- a/src/FubuCore.Testing/FubuCore.Testing.csproj
+++ b/src/FubuCore.Testing/FubuCore.Testing.csproj
@@ -262,7 +262,6 @@
     <None Include="Configuration\Two.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/FubuCore.Testing/Util/CacheTester.cs
+++ b/src/FubuCore.Testing/Util/CacheTester.cs
@@ -88,16 +88,6 @@ namespace FubuCore.Testing.Util
         }
 
         [Test]
-        public void get_first_value()
-        {
-            cache.Fill(Key, 42);
-            cache.Fill("anotherKey", 99);
-            cache.First.ShouldEqual(42);
-            cache.ClearAll();
-            cache.First.ShouldEqual(0);
-        }
-
-        [Test]
         public void get_all_keys()
         {
             cache.Fill(Key, 42);

--- a/src/FubuCore/Binding/InMemoryRequestData.cs
+++ b/src/FubuCore/Binding/InMemoryRequestData.cs
@@ -6,13 +6,13 @@ namespace FubuCore.Binding
 {
     public class InMemoryRequestData : RequestData
     {
-        private readonly Cache<string, object> _values;
+        private readonly IDictionary<string, object> _values;
 
 
         private InMemoryRequestData(IDictionary<string, object> values)
             : base(new FlatValueSource<object>(values, "in memory"))
         {
-            _values = new Cache<string, object>(values);
+            _values = values;
         }
 
 
@@ -33,7 +33,7 @@ namespace FubuCore.Binding
 
         public IEnumerable<string> GetKeys()
         {
-            return _values.GetAllKeys();
+            return _values.Keys;
         }
     }
 }


### PR DESCRIPTION
Changed Cache to use ConcurrentDictionary, since it's frequently used in multithreaded scenarios.  InMemoryRequestData was also changed to fix breaking tests since it was relying on an implementation detail of the Cache.
