### PR TITLE
Make the exception throw be more explicit about what cycles exist.

### DIFF
--- a/src/FubuCore/DependencyAnalysis/DependencyGraph.cs
+++ b/src/FubuCore/DependencyAnalysis/DependencyGraph.cs
@@ -36,7 +36,13 @@ namespace FubuCore.DependencyAnalysis
 
         public bool HasCycles()
         {
-            var cycles = _cycleDetector.FindCycles().ToList();
+            List<Cycle> cycles;
+            return HasCycles (out cycles);
+        }
+
+        public bool HasCycles(out List<Cycle> cycles)
+        {
+            cycles = _cycleDetector.FindCycles().ToList();
             return cycles.Count() > 0;
         }
 
@@ -75,8 +81,15 @@ namespace FubuCore.DependencyAnalysis
 
         public IEnumerable<string> GetLoadOrder()
         {
-            if(HasCycles())
-                throw new InvalidOperationException("This graph has dependency cycles and cannot be ordered!");
+            List<Cycle> cycles;
+            if (HasCycles (out cycles))
+            {
+                var cycleDescription = cycles.Select (x => x.Name).Join (Environment.NewLine);
+                throw new InvalidOperationException (
+                    @"This graph has dependency cycles and cannot be ordered!
+                    The following cycles exist:
+                    {0}".ToFormat(cycleDescription));
+            }
 
             foreach (var node in _cycleDetector.Order())
             {


### PR DESCRIPTION
Calling GetLoadOrder throws an exception if there are cycles but provides absolutely no information as to what these are.

This manifests itself in ripple as 

mono ripple/src/ripple/bin/Debug/ripple.exe describe-graph
Trying to read a Ripple SolutionGraph from /home/alistair/Projects/fubu
ERROR: System.InvalidOperationException: This graph has dependency cycles and cannot be ordered!

this patch means that we would now get

mono ripple/src/ripple/bin/Debug/ripple.exe describe-graph
Trying to read a Ripple SolutionGraph from /home/alistair/Projects/fubu
ERROR: System.InvalidOperationException: This graph has dependency cycles and cannot be ordered!
The following cycles exist:
bottles->FubuMVC.Core.Assets->fubumvc->FubuCsProjFile
