### PR TITLE
Adding Union extension method overload to generic enumerable extensions

### DIFF
--- a/src/FubuCore.Testing/GenericEnumerableExtensionsTester.cs
+++ b/src/FubuCore.Testing/GenericEnumerableExtensionsTester.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using FubuTestingSupport;
 using NUnit.Framework;
+using StructureMap.Pipeline;
 
 namespace FubuCore.Testing
 {
@@ -83,6 +84,30 @@ namespace FubuCore.Testing
             Func<string, bool> whereEvaluator = item => item.CompareTo("c") < 0;
             list.RemoveAll(whereEvaluator);
             list.ShouldHaveCount(1).ShouldContain("c");
+        }
+
+        [Test]
+        public void unions_param_args()
+        {
+            var list = new List<string> {"a", "c", "b"};
+            var union = list.Union("d", "b", "e");
+            union.ShouldHaveTheSameElementsAs("a", "c", "b", "d", "e");
+        }
+
+        [Test]
+        public void unions_param_args_none()
+        {
+            var list = new List<string> {"a", "c", "b"};
+            var union = list.Union();
+            union.ShouldHaveTheSameElementsAs("a", "c", "b");
+        }
+
+        [Test]
+        public void unions_param_args_empty_array()
+        {
+            var list = new List<string> {"a", "c", "b"};
+            var union = list.Union(new string[0]);
+            union.ShouldHaveTheSameElementsAs("a", "c", "b");
         }
     }
 }

--- a/src/FubuCore/EnumerableExtensions.cs
+++ b/src/FubuCore/EnumerableExtensions.cs
@@ -142,5 +142,10 @@ namespace System.Collections.Generic
 
             return true;
         }
+
+        public static IEnumerable<T> Union<T>(this IEnumerable<T> first, params T[] second)
+        {
+            return first.Union(second as IEnumerable<T>);
+        } 
     }
 }


### PR DESCRIPTION
Linq already has a `Union` extension method but it only takes an `IEnumerable<T>` so if you wanted to add one item to an existing enumerable you would do `source.Union(new [] { item})` just to append it. This new extension allows you to do `source.Union(item1)` or `source.Union(item1, item2, ..., itemN)`
