### PR TITLE
Fixed TimeSpanConverter so it handles standard TimeSpan format strings

### DIFF
--- a/src/FubuCore.Testing/Conversion/TimeSpanConverterTester.cs
+++ b/src/FubuCore.Testing/Conversion/TimeSpanConverterTester.cs
@@ -19,5 +19,52 @@ namespace FubuCore.Testing.Conversion
         {
             TimeSpanConverter.GetTimeSpan("12:30").ShouldEqual(new TimeSpan(12, 30, 0));
         }
+
+        [Test]
+        public void converts_timespans_for_seconds()
+        {
+            TimeSpanConverter.GetTimeSpan("3.5s").ShouldEqual(TimeSpan.FromSeconds(3.5));
+            TimeSpanConverter.GetTimeSpan("5 s").ShouldEqual(TimeSpan.FromSeconds(5));
+            TimeSpanConverter.GetTimeSpan("1 second").ShouldEqual(TimeSpan.FromSeconds(1));
+            TimeSpanConverter.GetTimeSpan("12 seconds").ShouldEqual(TimeSpan.FromSeconds(12));
+        }
+
+        [Test]
+        public void converts_timespans_for_minutes()
+        {
+            TimeSpanConverter.GetTimeSpan("10m").ShouldEqual(TimeSpan.FromMinutes(10));
+            TimeSpanConverter.GetTimeSpan("2.1 m").ShouldEqual(TimeSpan.FromMinutes(2.1));
+            TimeSpanConverter.GetTimeSpan("1 minute").ShouldEqual(TimeSpan.FromMinutes(1));
+            TimeSpanConverter.GetTimeSpan("5 minutes").ShouldEqual(TimeSpan.FromMinutes(5));
+        }
+
+        [Test]
+        public void converts_timespans_for_hours()
+        {
+            TimeSpanConverter.GetTimeSpan("24h").ShouldEqual(TimeSpan.FromHours(24));
+            TimeSpanConverter.GetTimeSpan("4 h").ShouldEqual(TimeSpan.FromHours(4));
+            TimeSpanConverter.GetTimeSpan("1 hour").ShouldEqual(TimeSpan.FromHours(1));
+            TimeSpanConverter.GetTimeSpan("12.5 hours").ShouldEqual(TimeSpan.FromHours(12.5));
+        }
+
+        [Test]
+        public void converts_timespans_for_days()
+        {
+            TimeSpanConverter.GetTimeSpan("3d").ShouldEqual(TimeSpan.FromDays(3));
+            TimeSpanConverter.GetTimeSpan("2 d").ShouldEqual(TimeSpan.FromDays(2));
+            TimeSpanConverter.GetTimeSpan("1 day").ShouldEqual(TimeSpan.FromDays(1));
+            TimeSpanConverter.GetTimeSpan("7 days").ShouldEqual(TimeSpan.FromDays(7));
+        }
+
+        [Test]
+        public void can_convert_from_standard_format()
+        {
+            TimeSpanConverter.GetTimeSpan("00:00:01").ShouldEqual(new TimeSpan(0, 0, 1));
+            TimeSpanConverter.GetTimeSpan("00:10:00").ShouldEqual(new TimeSpan(0, 10, 0));
+            TimeSpanConverter.GetTimeSpan("01:30:00").ShouldEqual(new TimeSpan(1, 30, 0));
+            TimeSpanConverter.GetTimeSpan("1.01:30:00").ShouldEqual(new TimeSpan(1, 1, 30, 0));
+            TimeSpanConverter.GetTimeSpan("-00:10:00").ShouldEqual(new TimeSpan(0, -10, 0));
+            TimeSpanConverter.GetTimeSpan("12:34:56.789").ShouldEqual(new TimeSpan(0, 12, 34, 56, 789));
+        }
     }
 }

--- a/src/FubuCore/Conversion/TimeSpanConverter.cs
+++ b/src/FubuCore/Conversion/TimeSpanConverter.cs
@@ -2,7 +2,6 @@ using System;
 using System.ComponentModel;
 using System.Text.RegularExpressions;
 using System.Linq;
-using FubuCore.Descriptions;
 
 namespace FubuCore.Conversion
 {
@@ -11,21 +10,21 @@ namespace FubuCore.Conversion
     {
         private const string TIMESPAN_PATTERN =
             @"
-(?<quantity>\d+     # quantity is expressed as some digits
-(\.\d+)?)           # optionally followed by a decimal point and more digits
+^(?<quantity>\d+    # quantity is expressed as some digits
+(\.\d+)?)           # optionally followed by a decimal point or colon and more digits
 \s*                 # optional whitespace
-(?<units>\w+)       # units is expressed as a word";
+(?<units>[a-z]*)    # units is expressed as a word
+$                   # match the entire string";
 
 
         public static TimeSpan GetTimeSpan(string timeString)
         {
-            var match = Regex.Match(timeString, TIMESPAN_PATTERN, RegexOptions.IgnorePatternWhitespace);
+            var match = Regex.Match(timeString.Trim(), TIMESPAN_PATTERN, RegexOptions.IgnorePatternWhitespace);
             if (!match.Success)
             {
                 return TimeSpan.Parse(timeString);
             }
 
-            
 
             var number = double.Parse(match.Groups["quantity"].Value);
             var units = match.Groups["units"].Value.ToLower();
@@ -35,6 +34,7 @@ namespace FubuCore.Conversion
                 case "second":
                 case "seconds":
                     return TimeSpan.FromSeconds(number);
+
                 case "m":
                 case "minute":
                 case "minutes":
@@ -49,7 +49,6 @@ namespace FubuCore.Conversion
                 case "day":
                 case "days":
                     return TimeSpan.FromDays(number);
-
             }
 
             if (timeString.Length == 4 && !timeString.Contains(":"))


### PR DESCRIPTION
Strings like 00:10:00 were still matching the regex and ended up getting an exception instead of falling back to TimeSpan.Parse(), so I made the regex slightly more restrictive.