### PR TITLE
Add escaping CSV support to array model binding

### DIFF
--- a/src/FubuCore.Docs/FubuCore.Docs.csproj
+++ b/src/FubuCore.Docs/FubuCore.Docs.csproj
@@ -51,8 +51,5 @@
   </Target>
   -->
   <ItemGroup>
-    <EmbeddedResource Include="pak-WebContent.zip" />
-  </ItemGroup>
-  <ItemGroup>
   </ItemGroup>
 </Project>

--- a/src/FubuCore.Testing/Binding/ArrayConverterFamilyTester.cs
+++ b/src/FubuCore.Testing/Binding/ArrayConverterFamilyTester.cs
@@ -30,5 +30,14 @@ namespace FubuCore.Testing.Binding
                 setup.Data("Strings=herp, derp"); 
             }).Model.Strings.ShouldHaveTheSameElementsAs("herp","derp");
         }
+
+        [Test]
+        public void will_convert_escaped_comma_delimited_list_into_string_array()
+        {
+            BindingScenario<HerpDerp>.For(setup =>
+            {
+                setup.Data(@"Strings=arp, ""derp,larp"", herp");
+            }).Model.Strings.ShouldHaveTheSameElementsAs("arp", "derp,larp", "herp");
+        }
     }
 }

--- a/src/FubuCore/Conversion/ArrayConverterFamily.cs
+++ b/src/FubuCore/Conversion/ArrayConverterFamily.cs
@@ -1,5 +1,7 @@
 using System;
 using System.ComponentModel;
+using System.Linq;
+using FubuCore.Csv;
 using FubuCore.Descriptions;
 
 namespace FubuCore.Conversion
@@ -45,12 +47,15 @@ namespace FubuCore.Conversion
                     return Array.CreateInstance(_innerType, 0);
                 }
 
-                var strings = stringValue.ToDelimitedArray();
-                var array = Array.CreateInstance(_innerType, strings.Length);
+                var csvTokenizer = new CsvTokenizer();
+                csvTokenizer.Read(stringValue);
+                var tokens = csvTokenizer.Tokens.Select(t=>t.Trim()).ToList();
 
-                for (var i = 0; i < strings.Length; i++)
+                var array = Array.CreateInstance(_innerType, tokens.Count);
+
+                for (var i = 0; i < tokens.Count; i++)
                 {
-                    var value = _inner.Convert(request.AnotherRequest(strings[i]));
+                    var value = _inner.Convert(request.AnotherRequest(tokens[i]));
                     array.SetValue(value, i);
                 }
 


### PR DESCRIPTION
Now using FubuCore's built in CSV parsing support `CsvTokenizer` to allow array model binding
to contain escaped commas or line returns.

Fixes #99.